### PR TITLE
Fix issue running comment stripper program on production machine

### DIFF
--- a/app/services/submission_comment_stripping_service.rb
+++ b/app/services/submission_comment_stripping_service.rb
@@ -36,11 +36,8 @@ class SubmissionCommentStrippingService
 
   def strip_comments(src:, dst:)
     CommandExecutor.instance.execute!(
-      "node #{program} #{src} #{dst}"
+      "node index.js #{src} #{dst}",
+      chdir: Rails.root.join('bin/comment_stripper')
     )
-  end
-
-  def program
-    Rails.root.join('bin/comment_stripper/index.js')
   end
 end


### PR DESCRIPTION
You can't run the script outside the project directory on the production machine:

```
    at bootstrapNodeJSCore (internal/bootstrap/node.js:623:3)
user@JK-ubuntu:~/mossu$ touch a.js
user@JK-ubuntu:~/mossu$ node /home/user/mossu/bin/comment_stripper/index.js a.js ./b.js
/home/user/mossu/bin/comment_stripper/node_modules/@babel/core/lib/config/files/plugins.js:152
    throw e;
    ^

Error: Cannot find module 'babel-plugin-macros' from '/home/user/mossu'
    at Function.resolveSync [as sync] (/home/user/mossu/bin/comment_stripper/node_modules/resolve/lib/sync.js:90:15)
    at resolveStandardizedName (/home/user/mossu/bin/comment_stripper/node_modules/@babel/core/lib/config/files/plugins.js:101:31)
    at resolvePlugin (/home/user/mossu/bin/comment_stripper/node_modules/@babel/core/lib/config/files/plugins.js:54:10)
    at loadPlugin (/home/user/mossu/bin/comment_stripper/node_modules/@babel/core/lib/config/files/plugins.js:62:20)
    at createDescriptor (/home/user/mossu/bin/comment_stripper/node_modules/@babel/core/lib/config/config-descriptors.js:154:9)
    at items.map (/home/user/mossu/bin/comment_stripper/node_modules/@babel/core/lib/config/config-descriptors.js:109:50)
    at Array.map (<anonymous>)
    at createDescriptors (/home/user/mossu/bin/comment_stripper/node_modules/@babel/core/lib/config/config-descriptors.js:109:29)
    at createPluginDescriptors (/home/user/mossu/bin/comment_stripper/node_modules/@babel/core/lib/config/config-descriptors.js:105:10)
    at plugins (/home/user/mossu/bin/comment_stripper/node_modules/@babel/core/lib/config/config-descriptors.js:40:19)
```